### PR TITLE
Update mediawiki_api dependency

### DIFF
--- a/commons_upload.gemspec
+++ b/commons_upload.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_runtime_dependency 'mediawiki_api', '~> 0.3.0'
+  spec.add_runtime_dependency 'mediawiki_api', '~> 0.4', '>= 0.4.1'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rake', '~> 10.1'
+  spec.add_development_dependency 'rubocop', '~> 0.33'
 end


### PR DESCRIPTION
Updated mediawiki_api dependency to use the latest 0.4.1 version and to
accept any higher minor version since the project uses semantic
versioning.

Also set explicit versions for development dependencies to appease `gem
build`.
