### PR TITLE
Enhance Uploading... progress report

### DIFF
--- a/lib/commons_upload.rb
+++ b/lib/commons_upload.rb
@@ -41,8 +41,16 @@ EOS
     client = MediawikiApi::Client.new ENV['MEDIAWIKI_API_UPLOAD_URL']
     client.log_in ENV['MEDIAWIKI_USER'], ENV['MEDIAWIKI_PASSWORD']
     Dir["#{screenshot_directory}/*.png"].each do |file_path|
-      puts "Uploading #{file_path}"
-      image file_path, client
+      print "Uploading #{file_path} ... "
+      STDOUT.flush
+      begin
+        image file_path, client
+        puts 'OK'
+      rescue StandardError => e
+        puts 'FAILED'
+        raise e
+      end
+      STDOUT.flush
     end
   end
 end


### PR DESCRIPTION
When being used with rake, the output is buffered. The progress report
lines "Uploading xxx" ends up being spurt in blocks when the buffer is
exhausted.

Use STDOUT.flush to explicitly dump the line when output is buffered.

While at it append 'OK' on success, and 'FAILED' whenever an exception
happens.

Closes #11