### PR TITLE
Handle exact duplicates on upload

### DIFF
--- a/lib/commons_upload.rb
+++ b/lib/commons_upload.rb
@@ -31,8 +31,14 @@ EOS
     file_name = File.basename(file_path, '')
     file_license = license(file_name)
 
-    client.upload_image(file_name, file_path, file_license, true)
-    sleep 5 # Restriction in bot speed: https://commons.wikimedia.org/wiki/Commons:Bots#Bot_speed
+    begin
+      client.upload_image(file_name, file_path, file_license, true)
+    rescue MediawikiApi::ApiError => mwerr
+      raise mwerr if mwerr.code != 'fileexists-no-change'
+      puts 'File already uploaded.'
+    ensure
+      sleep 5 # Restriction in bot speed: https://commons.wikimedia.org/wiki/Commons:Bots#Bot_speed
+    end
   end
 
   def self.images


### PR DESCRIPTION
When the uploaded file is an exact duplicate, MediaWiki yields an API
error 'fileexists-no-change'.

Rescue and ignore it so the script can continue uploading other files.

A better solution would be to ask a checksum of all images before
uploading and then only upload the ones not matching.

Closes #10