### PR TITLE
Properly handle progress output

### DIFF
--- a/lib/commons_upload.rb
+++ b/lib/commons_upload.rb
@@ -33,9 +33,10 @@ EOS
 
     begin
       client.upload_image(file_name, file_path, file_license, true)
+      return 'OK'
     rescue MediawikiApi::ApiError => mwerr
       raise mwerr if mwerr.code != 'fileexists-no-change'
-      puts 'File already uploaded.'
+      return 'OK (file already uploaded)'
     ensure
       sleep 5 # Restriction in bot speed: https://commons.wikimedia.org/wiki/Commons:Bots#Bot_speed
     end
@@ -50,8 +51,8 @@ EOS
       print "Uploading #{file_path} ... "
       STDOUT.flush
       begin
-        image file_path, client
-        puts 'OK'
+        message = image file_path, client
+        puts message
       rescue StandardError => e
         puts 'FAILED'
         raise e


### PR DESCRIPTION
When a duplicate file got uploaded, the OK message ended up on its own
line:

    Uploading foobar.png ... File already uploaded.
    OK

Change the image method to return a message. It still raises an
exception on error though.  The resulting output is now:

    Uploading foobar.png ... OK (file already uploaded)
    Uploading baz.png ... OK
    Uploading error.png ... FAILED
    <exception>